### PR TITLE
feat: Create missing pages and define page variables

### DIFF
--- a/page_config.py
+++ b/page_config.py
@@ -91,6 +91,41 @@ chatpdfbot_page = st.Page(
     icon=":material/picture_as_pdf:",
 )
 
+thanos_metrics = st.Page(
+    "views/thanos_metrics_app.py",
+    title="Thanos Metrics",
+    icon=":material/analytics:",
+)
+
+newrelic_data = st.Page(
+    "views/newrelic_data_app.py",
+    title="New Relic Data",
+    icon=":material/analytics:",
+)
+
+gcp_lb_metrics = st.Page(
+    "views/gcp_lb_metrics_app.py",
+    title="GCP LB Metrics",
+    icon=":material/analytics:",
+)
+
+lighthouse_runner = st.Page(
+    "views/lighthouse_runner_app.py",
+    title="Lighthouse Runner",
+    icon=":material/analytics:",
+)
+
+lighthouse_reports = st.Page(
+    "views/lighthouse_reports_app.py",
+    title="Lighthouse Reports",
+    icon=":material/analytics:",
+)
+
+apk_metrics = st.Page(
+    "views/apk_metrics_app.py",
+    title="APK Metrics",
+    icon=":material/analytics:",
+)
 # =====================
 # PAGE NAVIGATION STRUCTURE
 # =====================

--- a/views/apk_metrics_app.py
+++ b/views/apk_metrics_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="APK Metrics",
+    page_icon=":material/analytics:",
+)
+
+st.title("APK Metrics")
+
+st.write("This page is under construction.")

--- a/views/chatWithPDF.py
+++ b/views/chatWithPDF.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="Chat With PDF",
+    page_icon=":material/picture_as_pdf:",
+)
+
+st.title("Chat With PDF")
+
+st.write("This page is under construction.")

--- a/views/chatbot.py
+++ b/views/chatbot.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="Chat with Ollama",
+    page_icon=":material/smart_toy:",
+)
+
+st.title("Chat with Ollama")
+
+st.write("This page is under construction.")

--- a/views/gcanalyzer/gcanalyzerapp.py
+++ b/views/gcanalyzer/gcanalyzerapp.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="GC Log Analyzer",
+    page_icon=":material/memory:",
+)
+
+st.title("GC Log Analyzer")
+
+st.write("This page is under construction.")

--- a/views/gcp_lb_metrics_app.py
+++ b/views/gcp_lb_metrics_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="GCP LB Metrics",
+    page_icon=":material/analytics:",
+)
+
+st.title("GCP LB Metrics")
+
+st.write("This page is under construction.")

--- a/views/jfr_analyzer_app.py
+++ b/views/jfr_analyzer_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="JFR Analyzer",
+    page_icon=":material/track_changes:",
+)
+
+st.title("JFR Analyzer")
+
+st.write("This page is under construction.")

--- a/views/lighthouse_reports_app.py
+++ b/views/lighthouse_reports_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="Lighthouse Reports",
+    page_icon=":material/analytics:",
+)
+
+st.title("Lighthouse Reports")
+
+st.write("This page is under construction.")

--- a/views/lighthouse_runner_app.py
+++ b/views/lighthouse_runner_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="Lighthouse Runner",
+    page_icon=":material/analytics:",
+)
+
+st.title("Lighthouse Runner")
+
+st.write("This page is under construction.")

--- a/views/newrelic_data_app.py
+++ b/views/newrelic_data_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="New Relic Data",
+    page_icon=":material/analytics:",
+)
+
+st.title("New Relic Data")
+
+st.write("This page is under construction.")

--- a/views/thanos_metrics_app.py
+++ b/views/thanos_metrics_app.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+st.set_page_config(
+    page_title="Thanos Metrics",
+    page_icon=":material/analytics:",
+)
+
+st.title("Thanos Metrics")
+
+st.write("This page is under construction.")


### PR DESCRIPTION
This commit adds the following missing pages to the `views` directory:
- `jfr_analyzer_app.py`
- `gcanalyzer/gcanalyzerapp.py`
- `chatbot.py`
- `chatWithPDF.py`
- `thanos_metrics_app.py`
- `newrelic_data_app.py`
- `gcp_lb_metrics_app.py`
- `lighthouse_runner_app.py`
- `lighthouse_reports_app.py`
- `apk_metrics_app.py`

It also defines the corresponding page variables in `page_config.py` so that they can be added to the navigation structure.